### PR TITLE
Move Session Details panel to modal and description area

### DIFF
--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/page.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/page.tsx
@@ -22,6 +22,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { CloneSessionDialog } from "@/components/clone-session-dialog";
 import { Breadcrumbs } from "@/components/breadcrumbs";
+import { PageHeader } from "@/components/page-header";
 import { SessionHeader } from "./session-header";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, DropdownMenuSeparator } from "@/components/ui/dropdown-menu";
 import { GitHubConnectionCard } from "@/components/github-connection-card";

--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/session-header.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/session-header.tsx
@@ -62,7 +62,7 @@ export function SessionHeader({
           {session.spec.displayName && (
             <div className="text-sm text-gray-500">{session.metadata.name}</div>
           )}
-          <div className="text-xs text-gray-500 mt-1">
+          <div className="text-xs text-gray-500 mt-3">
             <span>{mode} session</span>
             <span className="mx-1">•</span>
             <span>{started || formatDistanceToNow(new Date(session.metadata.creationTimestamp), { addSuffix: true })}</span>

--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/session-header.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/session-header.tsx
@@ -63,10 +63,10 @@ export function SessionHeader({
           {session.spec.displayName && (
             <div className="text-sm text-gray-500">{session.metadata.name}</div>
           )}
-          <div className="text-xs text-gray-500 mt-1">
-            <span>{mode} session</span>
+          <div className="text-xs text-gray-500 mt-3">
+            <span>Started {started || formatDistanceToNow(new Date(session.metadata.creationTimestamp), { addSuffix: true })}</span>
             <span className="mx-1">•</span>
-            <span>{started || formatDistanceToNow(new Date(session.metadata.creationTimestamp), { addSuffix: true })}</span>
+            <span>{mode} session</span>
             <span className="mx-1">•</span>
             <span>{modelName}</span>
             <span className="mx-1">•</span>

--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/session-header.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/session-header.tsx
@@ -4,9 +4,10 @@ import { useState } from 'react';
 import { formatDistanceToNow, format } from 'date-fns';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { RefreshCw, Square, Trash2, Copy } from 'lucide-react';
+import { RefreshCw, Square, Trash2, Copy, MoreVertical, Info } from 'lucide-react';
 import { CloneSessionDialog } from '@/components/clone-session-dialog';
 import { SessionDetailsModal } from '@/components/session-details-modal';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, DropdownMenuSeparator } from '@/components/ui/dropdown-menu';
 import type { AgenticSession } from '@/types/agentic-session';
 import { getPhaseColor } from '@/utils/session-helpers';
 
@@ -37,6 +38,7 @@ export function SessionHeader({
   messageCount,
 }: SessionHeaderProps) {
   const [detailsModalOpen, setDetailsModalOpen] = useState(false);
+  const [promptExpanded, setPromptExpanded] = useState(false);
   
   const phase = session.status?.phase || "Pending";
   const canStop = phase === "Running" || phase === "Creating";
@@ -44,7 +46,7 @@ export function SessionHeader({
 
   const mode = session.spec?.interactive ? "Interactive" : "Headless";
   const started = session.status?.startTime 
-    ? `Started ${format(new Date(session.status.startTime), "PPp")}`
+    ? format(new Date(session.status.startTime), "PPp")
     : null;
   const modelName = session.spec.llmSettings.model;
 
@@ -61,10 +63,10 @@ export function SessionHeader({
           {session.spec.displayName && (
             <div className="text-sm text-gray-500">{session.metadata.name}</div>
           )}
-          <div className="text-xs text-gray-500 mt-3">
-            <span>{started || formatDistanceToNow(new Date(session.metadata.creationTimestamp), { addSuffix: true })}</span>
-            <span className="mx-1">•</span>
+          <div className="text-xs text-gray-500 mt-1">
             <span>{mode} session</span>
+            <span className="mx-1">•</span>
+            <span>{started || formatDistanceToNow(new Date(session.metadata.creationTimestamp), { addSuffix: true })}</span>
             <span className="mx-1">•</span>
             <span>{modelName}</span>
             <span className="mx-1">•</span>
@@ -97,27 +99,45 @@ export function SessionHeader({
               Stop
             </Button>
           )}
-          <CloneSessionDialog
-            session={session}
-            trigger={
+          
+          {/* Actions dropdown menu */}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
               <Button variant="outline" size="sm">
-                <Copy className="w-4 h-4 mr-2" />
-                Clone
+                <MoreVertical className="w-4 h-4" />
               </Button>
-            }
-            projectName={projectName}
-          />
-          {canDelete && (
-            <Button
-              variant="destructive"
-              size="sm"
-              onClick={onDelete}
-              disabled={actionLoading === "deleting"}
-            >
-              <Trash2 className="w-4 h-4 mr-2" />
-              Delete
-            </Button>
-          )}
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={() => setDetailsModalOpen(true)}>
+                <Info className="w-4 h-4 mr-2" />
+                View details
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <CloneSessionDialog
+                session={session}
+                trigger={
+                  <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
+                    <Copy className="w-4 h-4 mr-2" />
+                    Clone
+                  </DropdownMenuItem>
+                }
+                projectName={projectName}
+              />
+              {canDelete && (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    onClick={onDelete}
+                    disabled={actionLoading === "deleting"}
+                    className="text-red-600"
+                  >
+                    <Trash2 className="w-4 h-4 mr-2" />
+                    {actionLoading === "deleting" ? "Deleting..." : "Delete"}
+                  </DropdownMenuItem>
+                </>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
       </div>
 
@@ -128,6 +148,8 @@ export function SessionHeader({
         durationMs={durationMs}
         k8sResources={k8sResources}
         messageCount={messageCount}
+        promptExpanded={promptExpanded}
+        onPromptToggle={() => setPromptExpanded(!promptExpanded)}
       />
     </>
   );

--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/session-header.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/session-header.tsx
@@ -37,7 +37,6 @@ export function SessionHeader({
   messageCount,
 }: SessionHeaderProps) {
   const [detailsModalOpen, setDetailsModalOpen] = useState(false);
-  const [promptExpanded, setPromptExpanded] = useState(false);
   
   const phase = session.status?.phase || "Pending";
   const canStop = phase === "Running" || phase === "Creating";
@@ -45,7 +44,7 @@ export function SessionHeader({
 
   const mode = session.spec?.interactive ? "Interactive" : "Headless";
   const started = session.status?.startTime 
-    ? format(new Date(session.status.startTime), "PPp")
+    ? `Started ${format(new Date(session.status.startTime), "PPp")}`
     : null;
   const modelName = session.spec.llmSettings.model;
 
@@ -63,9 +62,9 @@ export function SessionHeader({
             <div className="text-sm text-gray-500">{session.metadata.name}</div>
           )}
           <div className="text-xs text-gray-500 mt-3">
-            <span>{mode} session</span>
-            <span className="mx-1">•</span>
             <span>{started || formatDistanceToNow(new Date(session.metadata.creationTimestamp), { addSuffix: true })}</span>
+            <span className="mx-1">•</span>
+            <span>{mode} session</span>
             <span className="mx-1">•</span>
             <span>{modelName}</span>
             <span className="mx-1">•</span>
@@ -129,8 +128,6 @@ export function SessionHeader({
         durationMs={durationMs}
         k8sResources={k8sResources}
         messageCount={messageCount}
-        promptExpanded={promptExpanded}
-        onPromptToggle={() => setPromptExpanded(!promptExpanded)}
       />
     </>
   );

--- a/components/frontend/src/app/projects/[name]/sessions/[sessionName]/session-header.tsx
+++ b/components/frontend/src/app/projects/[name]/sessions/[sessionName]/session-header.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { formatDistanceToNow } from 'date-fns';
+import { useState } from 'react';
+import { formatDistanceToNow, format } from 'date-fns';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { RefreshCw, Square, Trash2, Copy } from 'lucide-react';
 import { CloneSessionDialog } from '@/components/clone-session-dialog';
+import { SessionDetailsModal } from '@/components/session-details-modal';
 import type { AgenticSession } from '@/types/agentic-session';
 import { getPhaseColor } from '@/utils/session-helpers';
 
@@ -15,6 +17,12 @@ type SessionHeaderProps = {
   onRefresh: () => void;
   onStop: () => void;
   onDelete: () => void;
+  durationMs?: number;
+  k8sResources?: {
+    pvcName?: string;
+    pvcSize?: string;
+  };
+  messageCount: number;
 };
 
 export function SessionHeader({
@@ -24,70 +32,106 @@ export function SessionHeader({
   onRefresh,
   onStop,
   onDelete,
+  durationMs,
+  k8sResources,
+  messageCount,
 }: SessionHeaderProps) {
+  const [detailsModalOpen, setDetailsModalOpen] = useState(false);
+  const [promptExpanded, setPromptExpanded] = useState(false);
+  
   const phase = session.status?.phase || "Pending";
   const canStop = phase === "Running" || phase === "Creating";
   const canDelete = phase === "Completed" || phase === "Failed" || phase === "Stopped" || phase === "Error";
 
+  const mode = session.spec?.interactive ? "Interactive" : "Headless";
+  const started = session.status?.startTime 
+    ? format(new Date(session.status.startTime), "PPp")
+    : null;
+  const modelName = session.spec.llmSettings.model;
+
   return (
-    <div className="flex items-start justify-between">
-      <div>
-        <h1 className="text-2xl font-semibold flex items-center gap-2">
-          <span>{session.spec.displayName || session.metadata.name}</span>
-          <Badge className={getPhaseColor(phase)}>
-            {phase}
-          </Badge>
-        </h1>
-        {session.spec.displayName && (
-          <div className="text-sm text-gray-500">{session.metadata.name}</div>
-        )}
-        <div className="text-xs text-gray-500 mt-1">
-          Created {formatDistanceToNow(new Date(session.metadata.creationTimestamp), { addSuffix: true })}
+    <>
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold flex items-center gap-2">
+            <span>{session.spec.displayName || session.metadata.name}</span>
+            <Badge className={getPhaseColor(phase)}>
+              {phase}
+            </Badge>
+          </h1>
+          {session.spec.displayName && (
+            <div className="text-sm text-gray-500">{session.metadata.name}</div>
+          )}
+          <div className="text-xs text-gray-500 mt-1">
+            <span>{mode} session</span>
+            <span className="mx-1">•</span>
+            <span>{started || formatDistanceToNow(new Date(session.metadata.creationTimestamp), { addSuffix: true })}</span>
+            <span className="mx-1">•</span>
+            <span>{modelName}</span>
+            <span className="mx-1">•</span>
+            <button 
+              onClick={() => setDetailsModalOpen(true)}
+              className="text-blue-600 hover:underline"
+            >
+              View details
+            </button>
+          </div>
         </div>
-      </div>
-      <div className="flex gap-2">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={onRefresh}
-          disabled={actionLoading === "refreshing"}
-        >
-          <RefreshCw className={`w-4 h-4 mr-2 ${actionLoading === "refreshing" ? "animate-spin" : ""}`} />
-          Refresh
-        </Button>
-        {canStop && (
+        <div className="flex gap-2">
           <Button
             variant="outline"
             size="sm"
-            onClick={onStop}
-            disabled={actionLoading === "stopping"}
+            onClick={onRefresh}
+            disabled={actionLoading === "refreshing"}
           >
-            <Square className="w-4 h-4 mr-2" />
-            Stop
+            <RefreshCw className={`w-4 h-4 mr-2 ${actionLoading === "refreshing" ? "animate-spin" : ""}`} />
+            Refresh
           </Button>
-        )}
-        <CloneSessionDialog
-          session={session}
-          trigger={
-            <Button variant="outline" size="sm">
-              <Copy className="w-4 h-4 mr-2" />
-              Clone
+          {canStop && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onStop}
+              disabled={actionLoading === "stopping"}
+            >
+              <Square className="w-4 h-4 mr-2" />
+              Stop
             </Button>
-          }
-          projectName={projectName}
-        />
-        {canDelete && (
-          <Button
-            variant="destructive"
-            size="sm"
-            onClick={onDelete}
-            disabled={actionLoading === "deleting"}
-          >
-            <Trash2 className="w-4 h-4 mr-2" />
-            Delete
-          </Button>
-        )}
+          )}
+          <CloneSessionDialog
+            session={session}
+            trigger={
+              <Button variant="outline" size="sm">
+                <Copy className="w-4 h-4 mr-2" />
+                Clone
+              </Button>
+            }
+            projectName={projectName}
+          />
+          {canDelete && (
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={onDelete}
+              disabled={actionLoading === "deleting"}
+            >
+              <Trash2 className="w-4 h-4 mr-2" />
+              Delete
+            </Button>
+          )}
+        </div>
       </div>
-    </div>
+
+      <SessionDetailsModal
+        session={session}
+        open={detailsModalOpen}
+        onOpenChange={setDetailsModalOpen}
+        durationMs={durationMs}
+        k8sResources={k8sResources}
+        messageCount={messageCount}
+        promptExpanded={promptExpanded}
+        onPromptToggle={() => setPromptExpanded(!promptExpanded)}
+      />
+    </>
   );
 }

--- a/components/frontend/src/components/session-details-modal.tsx
+++ b/components/frontend/src/components/session-details-modal.tsx
@@ -2,6 +2,7 @@
 
 import { format } from 'date-fns';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Badge } from '@/components/ui/badge';
 import type { AgenticSession } from '@/types/agentic-session';
 import { getPhaseColor } from '@/utils/session-helpers';
 
@@ -53,9 +54,9 @@ export function SessionDetailsModal({
           <div className="space-y-3">
             <div className="flex items-start gap-3">
               <span className="font-semibold text-gray-700 min-w-[100px]">Status:</span>
-              <span className={`text-gray-900 font-semibold ${getPhaseColor(session.status?.phase || "Pending")}`}>
+              <Badge className={getPhaseColor(session.status?.phase || "Pending")}>
                 {session.status?.phase || "Pending"}
-              </span>
+              </Badge>
             </div>
             
             <div className="flex items-start gap-3">

--- a/components/frontend/src/components/session-details-modal.tsx
+++ b/components/frontend/src/components/session-details-modal.tsx
@@ -5,6 +5,23 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/u
 import type { AgenticSession } from '@/types/agentic-session';
 import { getPhaseColor } from '@/utils/session-helpers';
 
+function formatDuration(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  
+  if (hours > 0) {
+    const remainingMinutes = minutes % 60;
+    const remainingSeconds = seconds % 60;
+    return `${hours}h ${remainingMinutes}m ${remainingSeconds}s`;
+  } else if (minutes > 0) {
+    const remainingSeconds = seconds % 60;
+    return `${minutes}m ${remainingSeconds}s`;
+  } else {
+    return `${seconds}s`;
+  }
+}
+
 type SessionDetailsModalProps = {
   session: AgenticSession;
   open: boolean;
@@ -15,8 +32,6 @@ type SessionDetailsModalProps = {
     pvcSize?: string;
   };
   messageCount: number;
-  promptExpanded: boolean;
-  onPromptToggle: () => void;
 };
 
 export function SessionDetailsModal({
@@ -26,8 +41,6 @@ export function SessionDetailsModal({
   durationMs,
   k8sResources,
   messageCount,
-  promptExpanded,
-  onPromptToggle,
 }: SessionDetailsModalProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -69,13 +82,13 @@ export function SessionDetailsModal({
             
             <div className="flex items-start gap-3">
               <span className="font-semibold text-gray-700 min-w-[100px]">Duration:</span>
-              <span className="text-gray-900">{typeof durationMs === "number" ? `${durationMs}ms` : "-"}</span>
+              <span className="text-gray-900">{typeof durationMs === "number" ? formatDuration(durationMs) : "-"}</span>
             </div>
             
             {k8sResources?.pvcName && (
               <div className="flex items-start gap-3">
                 <span className="font-semibold text-gray-700 min-w-[100px]">PVC:</span>
-                <span className="text-gray-900 font-mono text-xs break-all">{k8sResources.pvcName}</span>
+                <span className="text-gray-900 font-mono break-all">{k8sResources.pvcName}</span>
               </div>
             )}
             
@@ -89,7 +102,7 @@ export function SessionDetailsModal({
             {session.status?.jobName && (
               <div className="flex items-start gap-3">
                 <span className="font-semibold text-gray-700 min-w-[100px]">K8s Job:</span>
-                <span className="text-gray-900 font-mono text-xs break-all">{session.status.jobName}</span>
+                <span className="text-gray-900 font-mono break-all">{session.status.jobName}</span>
               </div>
             )}
             
@@ -100,21 +113,13 @@ export function SessionDetailsModal({
           </div>
           
           {session.spec.prompt && (
-            <div className="pt-2 border-t">
-              <div className="flex items-start gap-3">
-                <span className="font-semibold text-gray-700 min-w-[100px]">Session prompt:</span>
-                <button
-                  onClick={onPromptToggle}
-                  className="text-blue-600 hover:underline text-sm"
-                >
-                  {promptExpanded ? "Hide" : "View"}
-                </button>
+            <div className="pt-2">
+              <div className="mb-2">
+                <span className="font-semibold text-gray-700">Session prompt:</span>
               </div>
-              {promptExpanded && (
-                <div className="mt-3 p-4 bg-gray-50 rounded-md border border-gray-200">
-                  <p className="whitespace-pre-wrap text-sm text-gray-800 leading-relaxed">{session.spec.prompt}</p>
-                </div>
-              )}
+              <div className="max-h-[200px] overflow-y-auto p-4 bg-gray-50 rounded-md border border-gray-200">
+                <p className="whitespace-pre-wrap text-sm text-gray-800 leading-relaxed">{session.spec.prompt}</p>
+              </div>
             </div>
           )}
         </div>

--- a/components/frontend/src/components/session-details-modal.tsx
+++ b/components/frontend/src/components/session-details-modal.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { format } from 'date-fns';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import type { AgenticSession } from '@/types/agentic-session';
+import { getPhaseColor } from '@/utils/session-helpers';
+
+type SessionDetailsModalProps = {
+  session: AgenticSession;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  durationMs?: number;
+  k8sResources?: {
+    pvcName?: string;
+    pvcSize?: string;
+  };
+  messageCount: number;
+  promptExpanded: boolean;
+  onPromptToggle: () => void;
+};
+
+export function SessionDetailsModal({
+  session,
+  open,
+  onOpenChange,
+  durationMs,
+  k8sResources,
+  messageCount,
+  promptExpanded,
+  onPromptToggle,
+}: SessionDetailsModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[500px] max-h-[90vh] overflow-y-auto">
+        <DialogHeader className="space-y-3">
+          <DialogTitle>Session Details</DialogTitle>
+        </DialogHeader>
+        
+        <div className="space-y-4">
+          <div className="space-y-3">
+            <div className="flex items-start gap-3">
+              <span className="font-semibold text-gray-700 min-w-[100px]">Status:</span>
+              <span className={`text-gray-900 font-semibold ${getPhaseColor(session.status?.phase || "Pending")}`}>
+                {session.status?.phase || "Pending"}
+              </span>
+            </div>
+            
+            <div className="flex items-start gap-3">
+              <span className="font-semibold text-gray-700 min-w-[100px]">Model:</span>
+              <span className="text-gray-900">{session.spec.llmSettings.model}</span>
+            </div>
+            
+            <div className="flex items-start gap-3">
+              <span className="font-semibold text-gray-700 min-w-[100px]">Temperature:</span>
+              <span className="text-gray-900">{session.spec.llmSettings.temperature}</span>
+            </div>
+            
+            <div className="flex items-start gap-3">
+              <span className="font-semibold text-gray-700 min-w-[100px]">Mode:</span>
+              <span className="text-gray-900">{session.spec?.interactive ? "Interactive" : "Headless"}</span>
+            </div>
+            
+            {session.status?.startTime && (
+              <div className="flex items-start gap-3">
+                <span className="font-semibold text-gray-700 min-w-[100px]">Started:</span>
+                <span className="text-gray-900">{format(new Date(session.status.startTime), "PPp")}</span>
+              </div>
+            )}
+            
+            <div className="flex items-start gap-3">
+              <span className="font-semibold text-gray-700 min-w-[100px]">Duration:</span>
+              <span className="text-gray-900">{typeof durationMs === "number" ? `${durationMs}ms` : "-"}</span>
+            </div>
+            
+            {k8sResources?.pvcName && (
+              <div className="flex items-start gap-3">
+                <span className="font-semibold text-gray-700 min-w-[100px]">PVC:</span>
+                <span className="text-gray-900 font-mono text-xs break-all">{k8sResources.pvcName}</span>
+              </div>
+            )}
+            
+            {k8sResources?.pvcSize && (
+              <div className="flex items-start gap-3">
+                <span className="font-semibold text-gray-700 min-w-[100px]">PVC Size:</span>
+                <span className="text-gray-900">{k8sResources.pvcSize}</span>
+              </div>
+            )}
+            
+            {session.status?.jobName && (
+              <div className="flex items-start gap-3">
+                <span className="font-semibold text-gray-700 min-w-[100px]">K8s Job:</span>
+                <span className="text-gray-900 font-mono text-xs break-all">{session.status.jobName}</span>
+              </div>
+            )}
+            
+            <div className="flex items-start gap-3">
+              <span className="font-semibold text-gray-700 min-w-[100px]">Messages:</span>
+              <span className="text-gray-900">{messageCount}</span>
+            </div>
+          </div>
+          
+          {session.spec.prompt && (
+            <div className="pt-2 border-t">
+              <div className="flex items-start gap-3">
+                <span className="font-semibold text-gray-700 min-w-[100px]">Session prompt:</span>
+                <button
+                  onClick={onPromptToggle}
+                  className="text-blue-600 hover:underline text-sm"
+                >
+                  {promptExpanded ? "Hide" : "View"}
+                </button>
+              </div>
+              {promptExpanded && (
+                <div className="mt-3 p-4 bg-gray-50 rounded-md border border-gray-200">
+                  <p className="whitespace-pre-wrap text-sm text-gray-800 leading-relaxed">{session.spec.prompt}</p>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/components/frontend/src/components/ui/dialog.tsx
+++ b/components/frontend/src/components/ui/dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { createPortal } from "react-dom";
 import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -40,16 +41,22 @@ const DialogContent = React.forwardRef<
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, children, ...props }, ref) => {
   const { open, onOpenChange } = React.useContext(DialogContext);
+  const [mounted, setMounted] = React.useState(false);
 
-  if (!open) return null;
+  React.useEffect(() => {
+    setMounted(true);
+    return () => setMounted(false);
+  }, []);
 
-  return (
+  if (!open || !mounted) return null;
+
+  const content = (
     <div className="fixed inset-0 z-50">
       <div
-        className="fixed inset-0 bg-black/50 backdrop-blur-sm"
+        className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm"
         onClick={() => onOpenChange(false)}
       />
-      <div className="fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2">
+      <div className="fixed left-1/2 top-1/2 z-[60] -translate-x-1/2 -translate-y-1/2">
         <div
           ref={ref}
           className={cn(
@@ -70,6 +77,8 @@ const DialogContent = React.forwardRef<
       </div>
     </div>
   );
+
+  return createPortal(content, document.body);
 });
 DialogContent.displayName = "DialogContent";
 


### PR DESCRIPTION
Adds the date started, session type, model selection, and "View details" button to the description area in the Session Details page. This gets us closer to the original design.

Clicking "View details" opens a modal that contains all of the geeky details that we currently include in a "Session Details" panel on the left-hand side of the page. I adjusted the duration to be human-readable as well.

I propose that we remove the "Session Details" panel to free up space for the other, more interactive/dynamic panels that we have. I suspect we'll need the space as we go forward.

cc @Daniel-Warner-X

## Today

<img width="3104" height="1726" alt="2025-11-08 13 45 59" src="https://github.com/user-attachments/assets/b1149672-6f12-4829-a8d5-8fa616a46c1f" />

## Original design

<img width="3016" height="1694" alt="2025-11-08 13 48 09" src="https://github.com/user-attachments/assets/b83c2e65-bf82-4cb1-9cb0-6fd78f3a9df2" />

## This PR

<img width="3344" height="1558" alt="2025-11-08 14 22 05" src="https://github.com/user-attachments/assets/6b27d06e-3056-4f82-9567-7255cbba7b7e" />

<img width="3170" height="1546" alt="2025-11-08 14 16 42" src="https://github.com/user-attachments/assets/d1a63d97-9c97-4f3e-a92a-e4378dd4fff8" />


