### PR TITLE
Git auth

### DIFF
--- a/components/backend/handlers/secrets.go
+++ b/components/backend/handlers/secrets.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"log"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -12,9 +11,9 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Runner secrets management
-// Config is stored in ProjectSettings.spec.runnerSecretsName
-// The Secret lives in the project namespace and stores key/value pairs for runners
+// Two-secret architecture (hardcoded secret names):
+// 1. ambient-runner-secrets: ANTHROPIC_API_KEY only (ignored when Vertex enabled)
+// 2. ambient-non-vertex-integrations: GITHUB_TOKEN, JIRA_*, custom keys (always injected)
 
 // ListNamespaceSecrets handles GET /api/projects/:projectName/secrets -> { items: [{name, createdAt}] }
 func ListNamespaceSecrets(c *gin.Context) {
@@ -51,103 +50,21 @@ func ListNamespaceSecrets(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"items": items})
 }
 
-// GetRunnerSecretsConfig handles GET /api/projects/:projectName/runner-secrets/config
-func GetRunnerSecretsConfig(c *gin.Context) {
-	projectName := c.Param("projectName")
-	_, reqDyn := GetK8sClientsForRequest(c)
-
-	gvr := GetProjectSettingsResource()
-	// ProjectSettings is a singleton per namespace named 'projectsettings'
-	obj, err := reqDyn.Resource(gvr).Namespace(projectName).Get(c.Request.Context(), "projectsettings", v1.GetOptions{})
-	if err != nil && !errors.IsNotFound(err) {
-		log.Printf("Failed to read ProjectSettings for %s: %v", projectName, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to read runner secrets config"})
-		return
-	}
-
-	secretName := ""
-	if obj != nil {
-		if spec, ok := obj.Object["spec"].(map[string]interface{}); ok {
-			if v, ok := spec["runnerSecretsName"].(string); ok {
-				secretName = v
-			}
-		}
-	}
-	c.JSON(http.StatusOK, gin.H{"secretName": secretName})
-}
-
-// UpdateRunnerSecretsConfig handles PUT /api/projects/:projectName/runner-secrets/config { secretName }
-func UpdateRunnerSecretsConfig(c *gin.Context) {
-	projectName := c.Param("projectName")
-	_, reqDyn := GetK8sClientsForRequest(c)
-
-	var req struct {
-		SecretName string `json:"secretName" binding:"required"`
-	}
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-	if strings.TrimSpace(req.SecretName) == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "secretName is required"})
-		return
-	}
-
-	// Operator owns ProjectSettings. If it exists, update; otherwise, return not found.
-	gvr := GetProjectSettingsResource()
-	obj, err := reqDyn.Resource(gvr).Namespace(projectName).Get(c.Request.Context(), "projectsettings", v1.GetOptions{})
-	if errors.IsNotFound(err) {
-		c.JSON(http.StatusNotFound, gin.H{"error": "ProjectSettings not found. Ensure the namespace is labeled ambient-code.io/managed=true and wait for operator."})
-		return
-	}
-	if err != nil {
-		log.Printf("Failed to read ProjectSettings for %s: %v", projectName, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to read runner secrets config"})
-		return
-	}
-
-	// Update spec.runnerSecretsName
-	spec, _ := obj.Object["spec"].(map[string]interface{})
-	if spec == nil {
-		spec = map[string]interface{}{}
-		obj.Object["spec"] = spec
-	}
-	spec["runnerSecretsName"] = req.SecretName
-
-	if _, err := reqDyn.Resource(gvr).Namespace(projectName).Update(c.Request.Context(), obj, v1.UpdateOptions{}); err != nil {
-		log.Printf("Failed to update ProjectSettings for %s: %v", projectName, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update runner secrets config"})
-		return
-	}
-
-	c.JSON(http.StatusOK, gin.H{"secretName": req.SecretName})
-}
+// Runner secrets (ANTHROPIC_API_KEY only)
+// Hardcoded secret name: "ambient-runner-secrets"
+// Only injected when Vertex is disabled
 
 // ListRunnerSecrets handles GET /api/projects/:projectName/runner-secrets -> { data: { key: value } }
 func ListRunnerSecrets(c *gin.Context) {
 	projectName := c.Param("projectName")
-	reqK8s, reqDyn := GetK8sClientsForRequest(c)
+	reqK8s, _ := GetK8sClientsForRequest(c)
+	if reqK8s == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid or missing token"})
+		c.Abort()
+		return
+	}
 
-	// Read config
-	gvr := GetProjectSettingsResource()
-	obj, err := reqDyn.Resource(gvr).Namespace(projectName).Get(c.Request.Context(), "projectsettings", v1.GetOptions{})
-	if err != nil && !errors.IsNotFound(err) {
-		log.Printf("Failed to read ProjectSettings for %s: %v", projectName, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to read runner secrets config"})
-		return
-	}
-	secretName := ""
-	if obj != nil {
-		if spec, ok := obj.Object["spec"].(map[string]interface{}); ok {
-			if v, ok := spec["runnerSecretsName"].(string); ok {
-				secretName = v
-			}
-		}
-	}
-	if secretName == "" {
-		c.JSON(http.StatusOK, gin.H{"data": map[string]string{}})
-		return
-	}
+	const secretName = "ambient-runner-secrets"
 
 	sec, err := reqK8s.CoreV1().Secrets(projectName).Get(c.Request.Context(), secretName, v1.GetOptions{})
 	if err != nil {
@@ -170,7 +87,12 @@ func ListRunnerSecrets(c *gin.Context) {
 // UpdateRunnerSecrets handles PUT /api/projects/:projectName/runner-secrets { data: { key: value } }
 func UpdateRunnerSecrets(c *gin.Context) {
 	projectName := c.Param("projectName")
-	reqK8s, reqDyn := GetK8sClientsForRequest(c)
+	reqK8s, _ := GetK8sClientsForRequest(c)
+	if reqK8s == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid or missing token"})
+		c.Abort()
+		return
+	}
 
 	var req struct {
 		Data map[string]string `json:"data" binding:"required"`
@@ -180,29 +102,8 @@ func UpdateRunnerSecrets(c *gin.Context) {
 		return
 	}
 
-	// Read config for secret name
-	gvr := GetProjectSettingsResource()
-	obj, err := reqDyn.Resource(gvr).Namespace(projectName).Get(c.Request.Context(), "projectsettings", v1.GetOptions{})
-	if err != nil && !errors.IsNotFound(err) {
-		log.Printf("Failed to read ProjectSettings for %s: %v", projectName, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to read runner secrets config"})
-		return
-	}
-	secretName := ""
-	if obj != nil {
-		if spec, ok := obj.Object["spec"].(map[string]interface{}); ok {
-			if v, ok := spec["runnerSecretsName"].(string); ok {
-				secretName = strings.TrimSpace(v)
-			}
-		}
-	}
-	if secretName == "" {
-		secretName = "ambient-runner-secrets"
-	}
+	const secretName = "ambient-runner-secrets"
 
-	// Do not create/update ProjectSettings here. The operator owns it.
-
-	// Try to get existing Secret
 	sec, err := reqK8s.CoreV1().Secrets(projectName).Get(c.Request.Context(), secretName, v1.GetOptions{})
 	if errors.IsNotFound(err) {
 		// Create new Secret
@@ -242,4 +143,97 @@ func UpdateRunnerSecrets(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"message": "runner secrets updated"})
+}
+
+// Integration secrets (GITHUB_TOKEN, JIRA_*, custom keys)
+// Hardcoded secret name: "ambient-non-vertex-integrations"
+// Always injected as env vars, regardless of Vertex setting
+
+// ListIntegrationSecrets handles GET /api/projects/:projectName/integration-secrets -> { data: { key: value } }
+func ListIntegrationSecrets(c *gin.Context) {
+	projectName := c.Param("projectName")
+	reqK8s, _ := GetK8sClientsForRequest(c)
+	if reqK8s == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid or missing token"})
+		c.Abort()
+		return
+	}
+
+	const secretName = "ambient-non-vertex-integrations"
+
+	sec, err := reqK8s.CoreV1().Secrets(projectName).Get(c.Request.Context(), secretName, v1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			c.JSON(http.StatusOK, gin.H{"data": map[string]string{}})
+			return
+		}
+		log.Printf("Failed to get Secret %s/%s: %v", projectName, secretName, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to read integration secrets"})
+		return
+	}
+
+	out := map[string]string{}
+	for k, v := range sec.Data {
+		out[k] = string(v)
+	}
+	c.JSON(http.StatusOK, gin.H{"data": out})
+}
+
+// UpdateIntegrationSecrets handles PUT /api/projects/:projectName/integration-secrets { data: { key: value } }
+func UpdateIntegrationSecrets(c *gin.Context) {
+	projectName := c.Param("projectName")
+	reqK8s, _ := GetK8sClientsForRequest(c)
+	if reqK8s == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid or missing token"})
+		c.Abort()
+		return
+	}
+
+	var req struct {
+		Data map[string]string `json:"data" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	const secretName = "ambient-non-vertex-integrations"
+
+	sec, err := reqK8s.CoreV1().Secrets(projectName).Get(c.Request.Context(), secretName, v1.GetOptions{})
+	if errors.IsNotFound(err) {
+		newSec := &corev1.Secret{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      secretName,
+				Namespace: projectName,
+				Labels:    map[string]string{"app": "ambient-integration-secrets"},
+				Annotations: map[string]string{
+					"ambient-code.io/runner-secret": "true",
+				},
+			},
+			Type:       corev1.SecretTypeOpaque,
+			StringData: req.Data,
+		}
+		if _, err := reqK8s.CoreV1().Secrets(projectName).Create(c.Request.Context(), newSec, v1.CreateOptions{}); err != nil {
+			log.Printf("Failed to create Secret %s/%s: %v", projectName, secretName, err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create integration secrets"})
+			return
+		}
+	} else if err != nil {
+		log.Printf("Failed to get Secret %s/%s: %v", projectName, secretName, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to read integration secrets"})
+		return
+	} else {
+		sec.Type = corev1.SecretTypeOpaque
+		sec.Data = map[string][]byte{}
+		for k, v := range req.Data {
+			sec.Data[k] = []byte(v)
+		}
+		if _, err := reqK8s.CoreV1().Secrets(projectName).Update(c.Request.Context(), sec, v1.UpdateOptions{}); err != nil {
+			log.Printf("Failed to update Secret %s/%s: %v", projectName, secretName, err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update integration secrets"})
+			return
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "integration secrets updated"})
 }

--- a/components/backend/routes.go
+++ b/components/backend/routes.go
@@ -91,10 +91,10 @@ func registerRoutes(r *gin.Engine) {
 			projectGroup.DELETE("/keys/:keyId", handlers.DeleteProjectKey)
 
 			projectGroup.GET("/secrets", handlers.ListNamespaceSecrets)
-			projectGroup.GET("/runner-secrets/config", handlers.GetRunnerSecretsConfig)
-			projectGroup.PUT("/runner-secrets/config", handlers.UpdateRunnerSecretsConfig)
 			projectGroup.GET("/runner-secrets", handlers.ListRunnerSecrets)
 			projectGroup.PUT("/runner-secrets", handlers.UpdateRunnerSecrets)
+			projectGroup.GET("/integration-secrets", handlers.ListIntegrationSecrets)
+			projectGroup.PUT("/integration-secrets", handlers.UpdateIntegrationSecrets)
 		}
 
 		api.POST("/auth/github/install", handlers.LinkGitHubInstallationGlobal)

--- a/components/frontend/src/app/api/projects/[name]/integration-secrets/route.ts
+++ b/components/frontend/src/app/api/projects/[name]/integration-secrets/route.ts
@@ -1,0 +1,41 @@
+import { BACKEND_URL } from '@/lib/config';
+import { buildForwardHeadersAsync } from '@/lib/auth';
+
+// GET /api/projects/[name]/integration-secrets
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ name: string }> }
+) {
+  try {
+    const { name } = await params;
+    const headers = await buildForwardHeadersAsync(request);
+    const response = await fetch(`${BACKEND_URL}/projects/${encodeURIComponent(name)}/integration-secrets`, { headers });
+    const text = await response.text();
+    return new Response(text, { status: response.status, headers: { 'Content-Type': 'application/json' } });
+  } catch (error) {
+    console.error('Error getting integration secrets:', error);
+    return Response.json({ error: 'Failed to get integration secrets' }, { status: 500 });
+  }
+}
+
+// PUT /api/projects/[name]/integration-secrets
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ name: string }> }
+) {
+  try {
+    const { name } = await params;
+    const body = await request.text();
+    const headers = await buildForwardHeadersAsync(request);
+    const response = await fetch(`${BACKEND_URL}/projects/${encodeURIComponent(name)}/integration-secrets`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body,
+    });
+    const text = await response.text();
+    return new Response(text, { status: response.status, headers: { 'Content-Type': 'application/json' } });
+  } catch (error) {
+    console.error('Error updating integration secrets:', error);
+    return Response.json({ error: 'Failed to update integration secrets' }, { status: 500 });
+  }
+}

--- a/components/frontend/src/components/workspace-sections/settings-section.tsx
+++ b/components/frontend/src/components/workspace-sections/settings-section.tsx
@@ -7,14 +7,12 @@ import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
-import { Save, Loader2, Info } from "lucide-react";
-import { Plus, Trash2, Eye, EyeOff } from "lucide-react";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Save, Loader2, Info, AlertTriangle } from "lucide-react";
+import { Plus, Trash2, Eye, EyeOff, ChevronDown, ChevronRight } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { successToast, errorToast } from "@/hooks/use-toast";
 import { useProject, useUpdateProject } from "@/services/queries/use-projects";
-import { useSecretsList, useSecretsConfig, useSecretsValues, useUpdateSecretsConfig, useUpdateSecrets } from "@/services/queries/use-secrets";
+import { useSecretsValues, useUpdateSecretsConfig, useUpdateSecrets, useIntegrationSecrets, useUpdateIntegrationSecrets } from "@/services/queries/use-secrets";
 import { useMemo } from "react";
 
 type SettingsSectionProps = {
@@ -23,9 +21,7 @@ type SettingsSectionProps = {
 
 export function SettingsSection({ projectName }: SettingsSectionProps) {
   const [formData, setFormData] = useState({ displayName: "", description: "" });
-  const [secretName, setSecretName] = useState<string>("");
   const [secrets, setSecrets] = useState<Array<{ key: string; value: string }>>([]);
-  const [mode, setMode] = useState<"existing" | "new">("existing");
   const [showValues, setShowValues] = useState<Record<number, boolean>>({});
   const [anthropicApiKey, setAnthropicApiKey] = useState<string>("");
   const [showAnthropicKey, setShowAnthropicKey] = useState<boolean>(false);
@@ -38,16 +34,19 @@ export function SettingsSection({ projectName }: SettingsSectionProps) {
   const [jiraEmail, setJiraEmail] = useState<string>("");
   const [jiraToken, setJiraToken] = useState<string>("");
   const [showJiraToken, setShowJiraToken] = useState<boolean>(false);
-  const FIXED_KEYS = useMemo(() => ["ANTHROPIC_API_KEY","GIT_USER_NAME","GIT_USER_EMAIL","GIT_TOKEN","JIRA_URL","JIRA_PROJECT","JIRA_EMAIL","JIRA_API_TOKEN"] as const, []);
+  const [anthropicExpanded, setAnthropicExpanded] = useState<boolean>(false);
+  const [githubExpanded, setGithubExpanded] = useState<boolean>(false);
+  const [jiraExpanded, setJiraExpanded] = useState<boolean>(false);
+  const FIXED_KEYS = useMemo(() => ["ANTHROPIC_API_KEY","GIT_USER_NAME","GIT_USER_EMAIL","GITHUB_TOKEN","JIRA_URL","JIRA_PROJECT","JIRA_EMAIL","JIRA_API_TOKEN"] as const, []);
 
   // React Query hooks
   const { data: project, isLoading: projectLoading } = useProject(projectName);
-  const { data: secretsList } = useSecretsList(projectName);
-  const { data: secretsConfig } = useSecretsConfig(projectName);
-  const { data: secretsValues } = useSecretsValues(projectName);
+  const { data: runnerSecrets } = useSecretsValues(projectName);  // ambient-runner-secrets (ANTHROPIC_API_KEY)
+  const { data: integrationSecrets } = useIntegrationSecrets(projectName);  // ambient-non-vertex-integrations (GITHUB_TOKEN, GIT_USER_*, JIRA_*, custom)
   const updateProjectMutation = useUpdateProject();
   const updateSecretsConfigMutation = useUpdateSecretsConfig();
   const updateSecretsMutation = useUpdateSecrets();
+  const updateIntegrationSecretsMutation = useUpdateIntegrationSecrets();
 
   // Sync project data to form
   useEffect(() => {
@@ -56,34 +55,22 @@ export function SettingsSection({ projectName }: SettingsSectionProps) {
     }
   }, [project]);
 
-  // Sync secrets config to state
+  // Sync secrets values to state (merge both secrets)
   useEffect(() => {
-    if (secretsConfig) {
-      if (secretsConfig.secretName) {
-        setSecretName(secretsConfig.secretName);
-        setMode("existing");
-      } else {
-        setSecretName("ambient-runner-secrets");
-        setMode("new");
-      }
-    }
-  }, [secretsConfig]);
-
-  // Sync secrets values to state
-  useEffect(() => {
-    if (secretsValues) {
-      const byKey: Record<string, string> = Object.fromEntries(secretsValues.map(s => [s.key, s.value]));
+    const allSecrets = [...(runnerSecrets || []), ...(integrationSecrets || [])];
+    if (allSecrets.length > 0) {
+      const byKey: Record<string, string> = Object.fromEntries(allSecrets.map(s => [s.key, s.value]));
       setAnthropicApiKey(byKey["ANTHROPIC_API_KEY"] || "");
       setGitUserName(byKey["GIT_USER_NAME"] || "");
       setGitUserEmail(byKey["GIT_USER_EMAIL"] || "");
-      setGitToken(byKey["GIT_TOKEN"] || "");
+      setGitToken(byKey["GITHUB_TOKEN"] || "");
       setJiraUrl(byKey["JIRA_URL"] || "");
       setJiraProject(byKey["JIRA_PROJECT"] || "");
       setJiraEmail(byKey["JIRA_EMAIL"] || "");
       setJiraToken(byKey["JIRA_API_TOKEN"] || "");
-      setSecrets(secretsValues.filter(s => !FIXED_KEYS.includes(s.key as typeof FIXED_KEYS[number])));
+      setSecrets(allSecrets.filter(s => !FIXED_KEYS.includes(s.key as typeof FIXED_KEYS[number])));
     }
-  }, [secretsValues, FIXED_KEYS]);
+  }, [runnerSecrets, integrationSecrets, FIXED_KEYS]);
 
   const handleSave = () => {
     if (!project) return;
@@ -111,51 +98,99 @@ export function SettingsSection({ projectName }: SettingsSectionProps) {
   const handleSaveSecrets = () => {
     if (!projectName) return;
 
-    const name = secretName.trim() || "ambient-runner-secrets";
+    // Split secrets into two groups
+    const runnerData: Record<string, string> = {};
+    const integrationData: Record<string, string> = {};
 
-    // First update config
-    updateSecretsConfigMutation.mutate(
-      { projectName, secretName: name },
-      {
-        onSuccess: () => {
-          // Then update secrets values
-          const data: Record<string, string> = {};
-          if (anthropicApiKey) data["ANTHROPIC_API_KEY"] = anthropicApiKey;
-          if (gitUserName) data["GIT_USER_NAME"] = gitUserName;
-          if (gitUserEmail) data["GIT_USER_EMAIL"] = gitUserEmail;
-          if (gitToken) data["GIT_TOKEN"] = gitToken;
-          if (jiraUrl) data["JIRA_URL"] = jiraUrl;
-          if (jiraProject) data["JIRA_PROJECT"] = jiraProject;
-          if (jiraEmail) data["JIRA_EMAIL"] = jiraEmail;
-          if (jiraToken) data["JIRA_API_TOKEN"] = jiraToken;
-          for (const { key, value } of secrets) {
-            if (!key) continue;
-            if (FIXED_KEYS.includes(key as typeof FIXED_KEYS[number])) continue;
-            data[key] = value ?? "";
-          }
+    // ANTHROPIC_API_KEY goes to ambient-runner-secrets
+    if (anthropicApiKey) runnerData["ANTHROPIC_API_KEY"] = anthropicApiKey;
 
-          updateSecretsMutation.mutate(
-            {
-              projectName,
-              secrets: Object.entries(data).map(([key, value]) => ({ key, value })),
-            },
-            {
-              onSuccess: () => {
-                successToast("Secrets saved successfully!");
-              },
-              onError: (error) => {
-                const message = error instanceof Error ? error.message : "Failed to save secrets";
-                errorToast(message);
-              },
-            }
-          );
-        },
-        onError: (error) => {
-          const message = error instanceof Error ? error.message : "Failed to save secret config";
-          errorToast(message);
-        },
+    // GITHUB_TOKEN, GIT_USER_*, JIRA_*, custom keys go to ambient-non-vertex-integrations
+    if (gitUserName) integrationData["GIT_USER_NAME"] = gitUserName;
+    if (gitUserEmail) integrationData["GIT_USER_EMAIL"] = gitUserEmail;
+    if (gitToken) integrationData["GITHUB_TOKEN"] = gitToken;
+    if (jiraUrl) integrationData["JIRA_URL"] = jiraUrl;
+    if (jiraProject) integrationData["JIRA_PROJECT"] = jiraProject;
+    if (jiraEmail) integrationData["JIRA_EMAIL"] = jiraEmail;
+    if (jiraToken) integrationData["JIRA_API_TOKEN"] = jiraToken;
+    for (const { key, value } of secrets) {
+      if (!key) continue;
+      if (FIXED_KEYS.includes(key as typeof FIXED_KEYS[number])) continue;
+      integrationData[key] = value ?? "";
+    }
+
+    const saveRunnerSecrets = Object.keys(runnerData).length > 0;
+    const saveIntegrationSecrets = Object.keys(integrationData).length > 0;
+
+    let completed = 0;
+    const total = (saveRunnerSecrets ? 1 : 0) + (saveIntegrationSecrets ? 1 : 0);
+    const savedSecrets: string[] = [];
+
+    const checkComplete = () => {
+      completed++;
+      if (completed === total) {
+        if (savedSecrets.length === 1) {
+          successToast(`Secrets saved to ${savedSecrets[0]}`);
+        } else if (savedSecrets.length === 2) {
+          successToast(`Secrets saved to ${savedSecrets[0]} and ${savedSecrets[1]}`);
+        }
       }
-    );
+    };
+
+    // Save runner secrets (ANTHROPIC_API_KEY)
+    if (saveRunnerSecrets) {
+      updateSecretsConfigMutation.mutate(
+        { projectName, secretName: "ambient-runner-secrets" },
+        {
+          onSuccess: () => {
+            updateSecretsMutation.mutate(
+              {
+                projectName,
+                secrets: Object.entries(runnerData).map(([key, value]) => ({ key, value })),
+              },
+              {
+                onSuccess: () => {
+                  savedSecrets.push("ambient-runner-secrets");
+                  checkComplete();
+                },
+                onError: (error) => {
+                  const message = error instanceof Error ? error.message : "Failed to save Anthropic API key";
+                  errorToast(message);
+                },
+              }
+            );
+          },
+          onError: (error) => {
+            const message = error instanceof Error ? error.message : "Failed to configure runner secrets";
+            errorToast(message);
+          },
+        }
+      );
+    }
+
+    // Save integration secrets (GIT_*, JIRA_*, custom)
+    if (saveIntegrationSecrets) {
+      updateIntegrationSecretsMutation.mutate(
+        {
+          projectName,
+          secrets: Object.entries(integrationData).map(([key, value]) => ({ key, value })),
+        },
+        {
+          onSuccess: () => {
+            savedSecrets.push("ambient-non-vertex-integrations");
+            checkComplete();
+          },
+          onError: (error) => {
+            const message = error instanceof Error ? error.message : "Failed to save integration secrets";
+            errorToast(message);
+          },
+        }
+      );
+    }
+
+    if (!saveRunnerSecrets && !saveIntegrationSecrets) {
+      errorToast("No secrets to save");
+    }
   };
 
   const addSecretRow = () => {
@@ -238,279 +273,217 @@ export function SettingsSection({ projectName }: SettingsSectionProps) {
 
       <Card>
         <CardHeader>
-          <CardTitle>Runner Secrets</CardTitle>
+          <CardTitle>Integration Secrets</CardTitle>
           <CardDescription>
-            Configure the Secret and manage key/value pairs used by workspace runners.
-          </CardDescription>
-        </CardHeader>
-        <Separator />
-        <CardContent className="space-y-4">
-          <div className="space-y-2">
-            <div className="flex items-center justify-between gap-3">
-              <div>
-                <Label>Runner Secret</Label>
-                <div className="text-sm text-muted-foreground">Using: {secretName || "ambient-runner-secrets"}</div>
-              </div>
-            </div>
-            <Tabs value={mode} onValueChange={(v) => setMode(v as typeof mode)}>
-              <TabsList>
-                <TabsTrigger value="existing">Use existing</TabsTrigger>
-                <TabsTrigger value="new">Create new</TabsTrigger>
-              </TabsList>
-              <TabsContent value="existing">
-                <div className="flex gap-2 items-center pt-2">
-                  {(secretsList?.items?.length ?? 0) > 0 && (
-                    <Select
-                      value={secretName}
-                      onValueChange={setSecretName}
-                    >
-                      <SelectTrigger className="w-80">
-                        <SelectValue placeholder="Select a secret..." />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {secretsList?.items?.map((s) => (
-                          <SelectItem key={s.name} value={s.name}>{s.name}</SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  )}
-                </div>
-                {(secretsList?.items?.length ?? 0) === 0 ? (
-                  <div className="mt-2 text-sm text-amber-600">No runner secrets found in this project. Use the &quot;Create new&quot; tab to create one.</div>
-                ) : (!secretName ? (
-                  <div className="mt-2 text-sm text-muted-foreground">No secret selected. You can still add key/value pairs below and Save; they will be written to the default secret name.</div>
-                ) : null)}
-              </TabsContent>
-              <TabsContent value="new">
-                <div className="flex gap-2 items-center pt-2">
-                  <Input
-                    id="secretName"
-                    value={secretName}
-                    onChange={(e) => setSecretName(e.target.value)}
-                    placeholder="ambient-runner-secrets"
-                    maxLength={253}
-                  />
-                </div>
-              </TabsContent>
-            </Tabs>
-          </div>
-
-          {(mode === "new" || (mode === "existing" && !!secretName)) && (
-            <div className="pt-2 space-y-4">
-              <div className="space-y-2">
-                <Label>Additional Secrets</Label>
-                <div className="space-y-2">
-                  {secrets.map((item, idx) => (
-                    <div key={idx} className="flex gap-2 items-center">
-                      <Input
-                        value={item.key}
-                        onChange={(e) =>
-                          setSecrets((prev) => prev.map((it, i) => (i === idx ? { ...it, key: e.target.value } : it)))
-                        }
-                        placeholder="KEY"
-                        className="w-1/3"
-                      />
-                      <div className="flex-1 flex items-center gap-2">
-                        <Input
-                          type={showValues[idx] ? "text" : "password"}
-                          value={item.value}
-                          onChange={(e) =>
-                            setSecrets((prev) => prev.map((it, i) => (i === idx ? { ...it, value: e.target.value } : it)))
-                          }
-                          placeholder="value"
-                          className="flex-1"
-                        />
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          onClick={() => setShowValues((prev) => ({ ...prev, [idx]: !prev[idx] }))}
-                          aria-label={showValues[idx] ? "Hide value" : "Show value"}
-                        >
-                          {showValues[idx] ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
-                        </Button>
-                      </div>
-                      <Button variant="ghost" onClick={() => removeSecretRow(idx)} aria-label="Remove row">
-                        <Trash2 className="w-4 h-4" />
-                      </Button>
-                    </div>
-                  ))}
-                </div>
-              </div>
-              <Button variant="outline" onClick={addSecretRow}>
-                <Plus className="w-4 h-4 mr-2" /> Add Secret
-              </Button>
-            </div>
-          )}
-
-          {(mode === "new" || (mode === "existing" && !!secretName)) && (
-            <div className="flex gap-3 pt-2">
-              <Button
-                onClick={handleSaveSecrets}
-                disabled={
-                  updateSecretsConfigMutation.isPending ||
-                  updateSecretsMutation.isPending ||
-                  (mode === "existing" && ((secretsList?.items?.length ?? 0) === 0 || !secretName))
-                }
-              >
-                {(updateSecretsConfigMutation.isPending || updateSecretsMutation.isPending) ? (
-                  <>
-                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                    Saving Secrets
-                  </>
-                ) : (
-                  <>
-                    <Save className="w-4 h-4 mr-2" />
-                    Save Secrets
-                  </>
-                )}
-              </Button>
-            </div>
-          )}
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>API Keys</CardTitle>
-          <CardDescription>
-            Configure API keys for your workspace runners.
-          </CardDescription>
-        </CardHeader>
-        <Separator />
-        <CardContent className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="anthropicApiKey">Anthropic API Key</Label>
-            <div className="text-xs text-muted-foreground mb-2">Your Anthropic API key for Claude Code runner</div>
-            <div className="flex items-center gap-2">
-              <Input
-                id="anthropicApiKey"
-                type={showAnthropicKey ? "text" : "password"}
-                placeholder="sk-ant-..."
-                value={anthropicApiKey}
-                onChange={(e) => setAnthropicApiKey(e.target.value)}
-                className="flex-1"
-              />
-              <Button type="button" variant="ghost" onClick={() => setShowAnthropicKey((v) => !v)} aria-label={showAnthropicKey ? "Hide key" : "Show key"}>
-                {showAnthropicKey ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
-              </Button>
-            </div>
-          </div>
-          <div className="pt-2">
-            <Button
-              onClick={handleSaveSecrets}
-              disabled={
-                updateSecretsConfigMutation.isPending ||
-                updateSecretsMutation.isPending ||
-                (mode === "existing" && ((secretsList?.items?.length ?? 0) === 0 || !secretName))
-              }
-            >
-              {(updateSecretsConfigMutation.isPending || updateSecretsMutation.isPending) ? (
-                <>
-                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                  Saving Keys
-                </>
-              ) : (
-                <>
-                  <Save className="w-4 h-4 mr-2" />
-                  Save Keys
-                </>
-              )}
-            </Button>
-          </div>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>Integrations</CardTitle>
-          <CardDescription>
-            Configure external integrations for your workspace runners.
+            Configure environment variables for workspace runners. All values are injected into runner pods.
           </CardDescription>
         </CardHeader>
         <Separator />
         <CardContent className="space-y-6">
-          <div className="space-y-3">
-            <Label className="text-base font-semibold">Git Integration (Optional)</Label>
-            <div className="text-xs text-muted-foreground mb-3">Configure Git credentials for repository operations (clone, commit, push)</div>
-            <div className="text-xs text-blue-600 bg-blue-50 border border-blue-200 rounded p-2 mb-3">
-              <strong>Note:</strong> These fields are only needed if you have not connected a GitHub Application. When GitHub App integration is configured, it will be used automatically and these fields will serve as a fallback.
-            </div>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-              <div className="space-y-1">
-                <Label htmlFor="gitUserName">Git User Name</Label>
-                <Input id="gitUserName" placeholder="Your Name" value={gitUserName} onChange={(e) => setGitUserName(e.target.value)} />
+          {/* Warning about centralized integrations */}
+          <Alert variant="default" className="border-amber-200 bg-amber-50">
+            <AlertTriangle className="h-4 w-4 text-amber-600" />
+            <AlertTitle className="text-amber-900">Centralized Integrations Recommended</AlertTitle>
+            <AlertDescription className="text-amber-800 text-sm">
+              <p>Cluster-level integrations (Vertex AI, GitHub App, Jira OAuth) are more secure than personal tokens. Only configure these secrets if centralized integrations are unavailable.</p>
+            </AlertDescription>
+          </Alert>
+
+          {/* Anthropic Section */}
+          <div className="border rounded-lg">
+            <button
+              type="button"
+              onClick={() => setAnthropicExpanded(!anthropicExpanded)}
+              className="w-full flex items-center justify-between p-3 hover:bg-muted/50 transition-colors rounded-lg"
+            >
+              <div className="flex items-center gap-2">
+                {anthropicExpanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+                <span className="font-semibold">Anthropic</span>
+                {anthropicApiKey && <span className="text-xs text-muted-foreground">(configured)</span>}
               </div>
-              <div className="space-y-1">
-                <Label htmlFor="gitUserEmail">Git User Email</Label>
-                <Input id="gitUserEmail" placeholder="you@example.com" value={gitUserEmail} onChange={(e) => setGitUserEmail(e.target.value)} />
+            </button>
+            {anthropicExpanded && (
+              <div className="px-3 pb-3 space-y-3 border-t pt-3">
+                <div className="space-y-2">
+                  <Label htmlFor="anthropicApiKey">ANTHROPIC_API_KEY</Label>
+                  <div className="text-xs text-muted-foreground">Your Anthropic API key for Claude Code runner</div>
+                  <div className="flex items-center gap-2">
+                    <Input
+                      id="anthropicApiKey"
+                      type={showAnthropicKey ? "text" : "password"}
+                      placeholder="sk-ant-..."
+                      value={anthropicApiKey}
+                      onChange={(e) => setAnthropicApiKey(e.target.value)}
+                      className="flex-1"
+                    />
+                    <Button type="button" variant="ghost" size="sm" onClick={() => setShowAnthropicKey((v) => !v)} aria-label={showAnthropicKey ? "Hide key" : "Show key"}>
+                      {showAnthropicKey ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* GitHub Integration Section */}
+          <div className="border rounded-lg">
+            <button
+              type="button"
+              onClick={() => setGithubExpanded(!githubExpanded)}
+              className="w-full flex items-center justify-between p-3 hover:bg-muted/50 transition-colors rounded-lg"
+            >
+              <div className="flex items-center gap-2">
+                {githubExpanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+                <span className="font-semibold">GitHub Integration</span>
+                {(gitUserName || gitUserEmail || gitToken) && <span className="text-xs text-muted-foreground">(configured)</span>}
+              </div>
+            </button>
+            {githubExpanded && (
+              <div className="px-3 pb-3 space-y-3 border-t pt-3">
+                <div className="text-xs text-muted-foreground">Configure Git credentials for repository operations (clone, commit, push)</div>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                  <div className="space-y-1">
+                    <Label htmlFor="gitUserName">GIT_USER_NAME</Label>
+                    <Input id="gitUserName" placeholder="Your Name" value={gitUserName} onChange={(e) => setGitUserName(e.target.value)} />
+                  </div>
+                  <div className="space-y-1">
+                    <Label htmlFor="gitUserEmail">GIT_USER_EMAIL</Label>
+                    <Input id="gitUserEmail" placeholder="you@example.com" value={gitUserEmail} onChange={(e) => setGitUserEmail(e.target.value)} />
+                  </div>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="gitToken">GITHUB_TOKEN</Label>
+                  <div className="text-xs text-muted-foreground mb-1">GitHub personal access token or fine-grained token for git operations and API access</div>
+                  <div className="flex items-center gap-2">
+                    <Input
+                      id="gitToken"
+                      type={showGitToken ? "text" : "password"}
+                      placeholder="ghp_... or glpat-..."
+                      value={gitToken}
+                      onChange={(e) => setGitToken(e.target.value)}
+                      className="flex-1"
+                    />
+                    <Button type="button" variant="ghost" size="sm" onClick={() => setShowGitToken((v) => !v)} aria-label={showGitToken ? "Hide token" : "Show token"}>
+                      {showGitToken ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Jira Integration Section */}
+          <div className="border rounded-lg">
+            <button
+              type="button"
+              onClick={() => setJiraExpanded(!jiraExpanded)}
+              className="w-full flex items-center justify-between p-3 hover:bg-muted/50 transition-colors rounded-lg"
+            >
+              <div className="flex items-center gap-2">
+                {jiraExpanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+                <span className="font-semibold">Jira Integration</span>
+                {(jiraUrl || jiraProject || jiraEmail || jiraToken) && <span className="text-xs text-muted-foreground">(configured)</span>}
+              </div>
+            </button>
+            {jiraExpanded && (
+              <div className="px-3 pb-3 space-y-3 border-t pt-3">
+                <div className="text-xs text-muted-foreground">Configure Jira integration for issue management</div>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                  <div className="space-y-1">
+                    <Label htmlFor="jiraUrl">JIRA_URL</Label>
+                    <Input id="jiraUrl" placeholder="https://your-domain.atlassian.net" value={jiraUrl} onChange={(e) => setJiraUrl(e.target.value)} />
+                  </div>
+                  <div className="space-y-1">
+                    <Label htmlFor="jiraProject">JIRA_PROJECT</Label>
+                    <Input id="jiraProject" placeholder="ABC" value={jiraProject} onChange={(e) => setJiraProject(e.target.value)} />
+                  </div>
+                  <div className="space-y-1">
+                    <Label htmlFor="jiraEmail">JIRA_EMAIL</Label>
+                    <Input id="jiraEmail" placeholder="you@example.com" value={jiraEmail} onChange={(e) => setJiraEmail(e.target.value)} />
+                  </div>
+                  <div className="space-y-1">
+                    <Label htmlFor="jiraToken">JIRA_API_TOKEN</Label>
+                    <div className="flex items-center gap-2">
+                      <Input id="jiraToken" type={showJiraToken ? "text" : "password"} placeholder="token" value={jiraToken} onChange={(e) => setJiraToken(e.target.value)} />
+                      <Button type="button" variant="ghost" size="sm" onClick={() => setShowJiraToken((v) => !v)} aria-label={showJiraToken ? "Hide token" : "Show token"}>
+                        {showJiraToken ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Custom Environment Variables Section */}
+          <div className="space-y-3 pt-2">
+            <div className="flex items-center justify-between">
+              <div>
+                <Label className="text-base font-semibold">Custom Environment Variables</Label>
+                <div className="text-xs text-muted-foreground mt-1">Add any additional environment variables for your integrations</div>
               </div>
             </div>
             <div className="space-y-2">
-              <Label htmlFor="gitToken">GitHub API Token</Label>
-              <div className="flex items-center gap-2">
-                <Input
-                  id="gitToken"
-                  type={showGitToken ? "text" : "password"}
-                  placeholder="ghp_... or glpat-..."
-                  value={gitToken}
-                  onChange={(e) => setGitToken(e.target.value)}
-                  className="flex-1"
-                />
-                <Button type="button" variant="ghost" onClick={() => setShowGitToken((v) => !v)} aria-label={showGitToken ? "Hide token" : "Show token"}>
-                  {showGitToken ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
-                </Button>
-              </div>
-              <div className="text-xs text-muted-foreground">GitHub personal access token or fine-grained token for git operations and API access</div>
-            </div>
-            <div className="text-xs text-muted-foreground">Git credentials will be saved with keys: GIT_USER_NAME, GIT_USER_EMAIL, GIT_TOKEN</div>
-          </div>
-
-          <div className="pt-4 space-y-3 border-t">
-            <Label className="text-base font-semibold">Jira Integration (Optional)</Label>
-            <div className="text-xs text-muted-foreground mb-3">Configure Jira integration for issue management</div>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-              <div className="space-y-1">
-                <Label htmlFor="jiraUrl">Jira Base URL</Label>
-                <Input id="jiraUrl" placeholder="https://your-domain.atlassian.net" value={jiraUrl} onChange={(e) => setJiraUrl(e.target.value)} />
-              </div>
-              <div className="space-y-1">
-                <Label htmlFor="jiraProject">Jira Project Key</Label>
-                <Input id="jiraProject" placeholder="ABC" value={jiraProject} onChange={(e) => setJiraProject(e.target.value)} />
-              </div>
-              <div className="space-y-1">
-                <Label htmlFor="jiraEmail">Jira Email/Username</Label>
-                <Input id="jiraEmail" placeholder="you@example.com" value={jiraEmail} onChange={(e) => setJiraEmail(e.target.value)} />
-              </div>
-              <div className="space-y-1">
-                <Label htmlFor="jiraToken">Jira API Token</Label>
-                <div className="flex items-center gap-2">
-                  <Input id="jiraToken" type={showJiraToken ? "text" : "password"} placeholder="token" value={jiraToken} onChange={(e) => setJiraToken(e.target.value)} />
-                  <Button type="button" variant="ghost" onClick={() => setShowJiraToken((v) => !v)} aria-label={showJiraToken ? "Hide token" : "Show token"}>
-                    {showJiraToken ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+              {secrets.map((item, idx) => (
+                <div key={idx} className="flex gap-2 items-center">
+                  <Input
+                    value={item.key}
+                    onChange={(e) =>
+                      setSecrets((prev) => prev.map((it, i) => (i === idx ? { ...it, key: e.target.value } : it)))
+                    }
+                    placeholder="KEY"
+                    className="w-1/3"
+                  />
+                  <div className="flex-1 flex items-center gap-2">
+                    <Input
+                      type={showValues[idx] ? "text" : "password"}
+                      value={item.value}
+                      onChange={(e) =>
+                        setSecrets((prev) => prev.map((it, i) => (i === idx ? { ...it, value: e.target.value } : it)))
+                      }
+                      placeholder="value"
+                      className="flex-1"
+                    />
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setShowValues((prev) => ({ ...prev, [idx]: !prev[idx] }))}
+                      aria-label={showValues[idx] ? "Hide value" : "Show value"}
+                    >
+                      {showValues[idx] ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                    </Button>
+                  </div>
+                  <Button variant="ghost" size="sm" onClick={() => removeSecretRow(idx)} aria-label="Remove row">
+                    <Trash2 className="w-4 h-4" />
                   </Button>
                 </div>
-              </div>
+              ))}
             </div>
-            <div className="text-xs text-muted-foreground">Jira credentials will be saved with keys: JIRA_URL, JIRA_PROJECT, JIRA_EMAIL, JIRA_API_TOKEN</div>
+            <Button variant="outline" size="sm" onClick={addSecretRow}>
+              <Plus className="w-4 h-4 mr-2" /> Add Environment Variable
+            </Button>
           </div>
-          <div className="pt-2">
+
+          {/* Save Button */}
+          <div className="pt-4 border-t">
             <Button
               onClick={handleSaveSecrets}
               disabled={
                 updateSecretsConfigMutation.isPending ||
                 updateSecretsMutation.isPending ||
-                (mode === "existing" && ((secretsList?.items?.length ?? 0) === 0 || !secretName))
+                updateIntegrationSecretsMutation.isPending
               }
             >
-              {(updateSecretsConfigMutation.isPending || updateSecretsMutation.isPending) ? (
+              {(updateSecretsConfigMutation.isPending || updateSecretsMutation.isPending || updateIntegrationSecretsMutation.isPending) ? (
                 <>
                   <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                  Saving Integrations
+                  Saving...
                 </>
               ) : (
                 <>
                   <Save className="w-4 h-4 mr-2" />
-                  Save Integrations
+                  Save Integration Secrets
                 </>
               )}
             </Button>

--- a/components/frontend/src/services/api/secrets.ts
+++ b/components/frontend/src/services/api/secrets.ts
@@ -75,3 +75,31 @@ export async function updateSecrets(
     { data }
   );
 }
+
+/**
+ * Get integration secrets values (GIT_*, JIRA_*, custom keys)
+ * Hardcoded secret name: "ambient-non-vertex-integrations"
+ */
+export async function getIntegrationSecrets(projectName: string): Promise<Secret[]> {
+  const data = await apiClient.get<Record<string, string>>(
+    `/projects/${projectName}/integration-secrets`
+  );
+  return Object.entries<string>(data || {}).map(([key, value]) => ({ key, value }));
+}
+
+/**
+ * Update integration secrets values (GIT_*, JIRA_*, custom keys)
+ * Hardcoded secret name: "ambient-non-vertex-integrations"
+ */
+export async function updateIntegrationSecrets(
+  projectName: string,
+  secrets: Secret[]
+): Promise<void> {
+  const data: Record<string, string> = Object.fromEntries(
+    secrets.map(s => [s.key, s.value])
+  );
+  await apiClient.put<void, { data: Record<string, string> }>(
+    `/projects/${projectName}/integration-secrets`,
+    { data }
+  );
+}

--- a/components/frontend/src/services/queries/use-secrets.ts
+++ b/components/frontend/src/services/queries/use-secrets.ts
@@ -60,3 +60,30 @@ export function useUpdateSecrets() {
     },
   });
 }
+
+// Integration secrets hooks (ambient-non-vertex-integrations)
+
+export function useIntegrationSecrets(projectName: string) {
+  return useQuery({
+    queryKey: ['integration-secrets', projectName],
+    queryFn: () => secretsApi.getIntegrationSecrets(projectName),
+    enabled: !!projectName,
+  });
+}
+
+export function useUpdateIntegrationSecrets() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      projectName,
+      secrets,
+    }: {
+      projectName: string;
+      secrets: secretsApi.Secret[];
+    }) => secretsApi.updateIntegrationSecrets(projectName, secrets),
+    onSuccess: (_, { projectName }) => {
+      queryClient.invalidateQueries({ queryKey: ['integration-secrets', projectName] });
+    },
+  });
+}

--- a/components/manifests/base/crds/kustomization.yaml
+++ b/components/manifests/base/crds/kustomization.yaml
@@ -3,5 +3,3 @@ kind: Kustomization
 resources:
 - agenticsessions-crd.yaml
 - projectsettings-crd.yaml
-
-

--- a/components/operator/internal/handlers/sessions.go
+++ b/components/operator/internal/handlers/sessions.go
@@ -311,18 +311,9 @@ func handleAgenticSessionEvent(obj *unstructured.Unstructured) error {
 	temperature, _, _ := unstructured.NestedFloat64(llmSettings, "temperature")
 	maxTokens, _, _ := unstructured.NestedInt64(llmSettings, "maxTokens")
 
-	// Read runner secrets configuration from ProjectSettings in the session's namespace
-	runnerSecretsName := ""
-	{
-		psGvr := types.GetProjectSettingsResource()
-		if psObj, err := config.DynamicClient.Resource(psGvr).Namespace(sessionNamespace).Get(context.TODO(), "projectsettings", v1.GetOptions{}); err == nil {
-			if psSpec, ok := psObj.Object["spec"].(map[string]interface{}); ok {
-				if v, ok := psSpec["runnerSecretsName"].(string); ok {
-					runnerSecretsName = strings.TrimSpace(v)
-				}
-			}
-		}
-	}
+	// Hardcoded secret names (convention over configuration)
+	const runnerSecretsName = "ambient-runner-secrets"              // ANTHROPIC_API_KEY only (ignored when Vertex enabled)
+	const integrationSecretsName = "ambient-non-vertex-integrations" // GIT_*, JIRA_*, custom keys (always injected)
 
 	// Extract input/output git configuration (support flat and nested forms)
 	inputRepo, _, _ := unstructured.NestedString(spec, "inputRepo")
@@ -583,18 +574,35 @@ func handleAgenticSessionEvent(obj *unstructured.Unstructured) error {
 								return base
 							}(),
 
-							// If configured, import all keys from the runner Secret as environment variables
-							// Note: When Vertex is enabled, use ambient-vertex secret instead of runnerSecretsName
+							// Import secrets as environment variables
+							// - integrationSecretsName: Always injected (GIT_TOKEN, JIRA_*, custom keys)
+							// - runnerSecretsName: Only when Vertex disabled (ANTHROPIC_API_KEY)
 							EnvFrom: func() []corev1.EnvFromSource {
-								// Warn if both Vertex and runnerSecretsName are configured
-								if vertexEnabled && runnerSecretsName != "" {
-									log.Printf("Warning: Both Vertex AI and runnerSecretsName configured for session %s. Using Vertex (runnerSecretsName ignored)", name)
+								sources := []corev1.EnvFromSource{}
+
+								// Always inject integration secrets if configured (regardless of Vertex)
+								if integrationSecretsName != "" {
+									sources = append(sources, corev1.EnvFromSource{
+										SecretRef: &corev1.SecretEnvSource{
+											LocalObjectReference: corev1.LocalObjectReference{Name: integrationSecretsName},
+										},
+									})
+									log.Printf("Injecting integration secrets from '%s' for session %s", integrationSecretsName, name)
 								}
-								// Only use runnerSecretsName when Vertex is disabled
+
+								// Only inject runner secrets (ANTHROPIC_API_KEY) when Vertex is disabled
 								if !vertexEnabled && runnerSecretsName != "" {
-									return []corev1.EnvFromSource{{SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: runnerSecretsName}}}}
+									sources = append(sources, corev1.EnvFromSource{
+										SecretRef: &corev1.SecretEnvSource{
+											LocalObjectReference: corev1.LocalObjectReference{Name: runnerSecretsName},
+										},
+									})
+									log.Printf("Injecting runner secrets from '%s' for session %s (Vertex disabled)", runnerSecretsName, name)
+								} else if vertexEnabled && runnerSecretsName != "" {
+									log.Printf("Skipping runner secrets '%s' for session %s (Vertex enabled)", runnerSecretsName, name)
 								}
-								return []corev1.EnvFromSource{}
+
+								return sources
 							}(),
 
 							Resources: corev1.ResourceRequirements{},
@@ -605,26 +613,8 @@ func handleAgenticSessionEvent(obj *unstructured.Unstructured) error {
 		},
 	}
 
-	// If a runner secret is configured, mount it as a volume in addition to EnvFrom
-	// Only use runnerSecretsName when Vertex AI is disabled (mutually exclusive with Vertex)
-	if !vertexEnabled && strings.TrimSpace(runnerSecretsName) != "" {
-		job.Spec.Template.Spec.Volumes = append(job.Spec.Template.Spec.Volumes, corev1.Volume{
-			Name:         "runner-secrets",
-			VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: runnerSecretsName}},
-		})
-		// Mount to the ambient-content container by name
-		for i := range job.Spec.Template.Spec.Containers {
-			if job.Spec.Template.Spec.Containers[i].Name == "ambient-content" {
-				job.Spec.Template.Spec.Containers[i].VolumeMounts = append(job.Spec.Template.Spec.Containers[i].VolumeMounts, corev1.VolumeMount{
-					Name:      "runner-secrets",
-					MountPath: "/var/run/runner-secrets",
-					ReadOnly:  true,
-				})
-				break
-			}
-		}
-		log.Printf("Mounted runnerSecretsName '%s' to /var/run/runner-secrets for session %s", runnerSecretsName, name)
-	}
+	// Note: No volume mounts needed for runner/integration secrets
+	// All keys are injected as environment variables via EnvFrom above
 
 	// If ambient-vertex secret was successfully copied, mount it as a volume
 	if ambientVertexSecretCopied {


### PR DESCRIPTION
Integration keys (GIT_*, JIRA_*) remain available when
Vertex AI manages ANTHROPIC_API_KEY.

- ambient-runner-secrets: ANTHROPIC_API_KEY only (ignored when Vertex enabled)
- ambient-non-vertex-integrations: GIT_TOKEN, JIRA_*, custom keys (always injected)

Fixes git authentication for Claude-initiated pushes by persisting token in
origin remote URL after clone. This enables Claude to push to GitHub at any
time during the session using standard git commands, not just via the
structured end-of-session auto-push feature.